### PR TITLE
Feat/param overrides

### DIFF
--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -3,7 +3,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, AndSubstitution
 from launch_ros.actions import Node
 from launch.conditions import IfCondition
 
@@ -187,7 +187,7 @@ def generate_launch_description():
             "params_file": mask_to_3d_params_file,
             "execute_default": execute_default,
         }.items(),
-        condition=IfCondition(use_mask_3d),
+        condition=IfCondition(AndSubstitution(use_3d, use_mask_3d)),
     )
 
     return LaunchDescription(

--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -12,6 +12,9 @@ def generate_launch_description():
     image_topic_name = LaunchConfiguration("image_topic_name")
     weight_file = LaunchConfiguration("weight_file")
     weights_path = LaunchConfiguration("weights_path")
+    bbox_to_3d_params_file = LaunchConfiguration("bbox_to_3d_params_file")
+    keypoint_to_3d_params_file = LaunchConfiguration("keypoint_to_3d_params_file")
+    mask_to_3d_params_file = LaunchConfiguration("mask_to_3d_params_file")
     execute_default = LaunchConfiguration("execute_default")
     conf = LaunchConfiguration("conf")
     iou = LaunchConfiguration("iou")
@@ -44,6 +47,33 @@ def generate_launch_description():
             "weights_path",
             default_value=os.path.join(get_package_share_directory("yolo_ros"), "weights"),
             description="Directory path where weight files are stored",
+        ),
+        DeclareLaunchArgument(
+            "bbox_to_3d_params_file",
+            default_value=os.path.join(
+                get_package_share_directory("image_to_position"),
+                "config",
+                "bbox_to_3d.yaml",
+            ),
+            description="Parameter file path for bbox_to_3d",
+        ),
+        DeclareLaunchArgument(
+            "keypoint_to_3d_params_file",
+            default_value=os.path.join(
+                get_package_share_directory("image_to_position"),
+                "config",
+                "keypoint_to_3d.yaml",
+            ),
+            description="Parameter file path for keypoint_to_3d",
+        ),
+        DeclareLaunchArgument(
+            "mask_to_3d_params_file",
+            default_value=os.path.join(
+                get_package_share_directory("image_to_position"),
+                "config",
+                "mask_to_3d.yaml",
+            ),
+            description="Parameter file path for mask_to_3d",
         ),
         DeclareLaunchArgument(
             "execute_default",
@@ -116,10 +146,7 @@ def generate_launch_description():
         ),
         launch_arguments={
             "namespace": namespace,
-            "params_file": os.path.join(
-                get_package_share_directory("image_to_position"), "config",
-                "bbox_to_3d.yaml"
-            ),
+            "params_file": bbox_to_3d_params_file,
             "execute_default": execute_default,
         }.items(),
         condition=IfCondition(use_3d),
@@ -135,10 +162,7 @@ def generate_launch_description():
         ),
         launch_arguments={
             "namespace": namespace,
-            "params_file": os.path.join(
-                get_package_share_directory("image_to_position"), "config",
-                "keypoint_to_3d.yaml"
-            ),
+            "params_file": keypoint_to_3d_params_file,
             "execute_default": execute_default,
         }.items(),
         condition=IfCondition(use_3d),

--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -18,6 +18,7 @@ def generate_launch_description():
     execute_default = LaunchConfiguration("execute_default")
     conf = LaunchConfiguration("conf")
     iou = LaunchConfiguration("iou")
+    use_mask_3d = LaunchConfiguration("use_mask_3d")
     use_3d = LaunchConfiguration("use_3d")
 
     launch_args = [
@@ -95,6 +96,11 @@ def generate_launch_description():
             default_value="True",
             description="Whether to activate 3D detections",
         ),
+        DeclareLaunchArgument(
+            "use_mask_3d",
+            default_value="False",
+            description="Whether to activate mask_to_3d",
+        ),
     ]
 
     yoloe_prompts = os.path.join(
@@ -168,10 +174,27 @@ def generate_launch_description():
         condition=IfCondition(use_3d),
     )
 
+    mask_to_3d_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("image_to_position"),
+                "launch",
+                "mask_to_3d.launch.py",
+            )
+        ),
+        launch_arguments={
+            "namespace": namespace,
+            "params_file": mask_to_3d_params_file,
+            "execute_default": execute_default,
+        }.items(),
+        condition=IfCondition(use_mask_3d),
+    )
+
     return LaunchDescription(
         launch_args + [
             yolo_node_cmd,
             bbox_to_3d_cmd,
             keypoint_to_3d_cmd,
+            mask_to_3d_cmd,
         ]
     )


### PR DESCRIPTION
## Summary

This PR adds launch argument overrides for the 3D conversion parameter files in `yolo.launch.py`, and also adds optional support for launching `mask_to_3d`. Specifically, it replaces hardcoded parameter file paths for `bbox_to_3d` and `keypoint_to_3d` with launch arguments, adds a new launch argument for `mask_to_3d`, and introduces a `use_mask_3d` flag to enable or disable the `mask_to_3d` launch include. :contentReference[oaicite:0]{index=0}

## Changes

- Added launch arguments:
  - `bbox_to_3d_params_file`
  - `keypoint_to_3d_params_file`
  - `mask_to_3d_params_file`
- Replaced hardcoded parameter file paths with the corresponding launch arguments
- Added `use_mask_3d` launch argument
- Added `mask_to_3d.launch.py` include to `yolo.launch.py`
- Made `mask_to_3d` execution conditional with `use_mask_3d` :contentReference[oaicite:1]{index=1}

## Why

This makes the launch file more flexible by allowing external parameter file overrides without editing the launch source directly. It also makes `mask_to_3d` integration optional and easier to enable when needed. :contentReference[oaicite:2]{index=2}

## Default behavior

- `bbox_to_3d_params_file` defaults to `image_to_position/config/bbox_to_3d.yaml`
- `keypoint_to_3d_params_file` defaults to `image_to_position/config/keypoint_to_3d.yaml`
- `mask_to_3d_params_file` defaults to `image_to_position/config/mask_to_3d.yaml`
- `use_mask_3d` defaults to `False` :contentReference[oaicite:3]{index=3}

## Testing

- Confirmed that `yolo.launch.py` accepts overridden 3D parameter file paths
- Confirmed that existing 3D launch includes for `bbox_to_3d` and `keypoint_to_3d` now use the passed launch arguments
- Confirmed that `mask_to_3d` is only launched when `use_mask_3d:=True` is set :contentReference[oaicite:4]{index=4}