### PR TITLE
[FEAT] Separate 3D launch flags for bbox, keypoint, and mask detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,22 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
 2. カスタムの重みファイルを使用する場合：
     - 用意した`.pt`ファイルを`weights`に配置してください．
 
-3. 3D座標変換（物体位置の推定）を有効にする場合：
+3. 3D座標変換（物体位置推定）を使用する場合は，必要な3Dパイプラインを起動引数で切り替える．
+
+    例：`bbox_to_3d` のみを有効にする場合
     ```sh
-    ros2 launch yolo_ros yolo.launch.py use_3d:=True
+    ros2 launch yolo_ros yolo.launch.py \
+      use_bbox_to_3d:=True \
+      use_keypoint_to_3d:=False \
+      use_mask_to_3d:=False
+    ```
+
+    例：`bbox_to_3d` と `keypoint_to_3d` を有効にする場合
+    ```sh
+    ros2 launch yolo_ros yolo.launch.py \
+      use_bbox_to_3d:=True \
+      use_keypoint_to_3d:=True \
+      use_mask_to_3d:=False
     ```
 
 ## パラメーター
@@ -103,6 +116,9 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
 | execute_default    | bool         | 起動時に自動でノードをConfigure/Activateするか |
 | conf               | double       | 検出の信頼度しきい値                       |
 | iou                | double       | NMSのIoUしきい値                      |
+| use_bbox_to_3d     | bool         | bbox_to_3d を起動するか                |
+| use_keypoint_to_3d | bool         | keypoint_to_3d を起動するか            |
+| use_mask_to_3d     | bool         | mask_to_3d を起動するか                |
 | filter_classes     | string_array | 検出対象を絞り込むクラス名のリスト                |
 | keypoint_name_list | string_array | 姿勢推定時のキーポイント名のリスト                |
 | yoloe_prompts      | string_array | YOLOEで使用する検出プロンプト                |

--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -19,8 +19,9 @@ def generate_launch_description():
     execute_default = LaunchConfiguration("execute_default")
     conf = LaunchConfiguration("conf")
     iou = LaunchConfiguration("iou")
-    use_mask_3d = LaunchConfiguration("use_mask_3d")
-    use_3d = LaunchConfiguration("use_3d")
+    use_bbox_to_3d = LaunchConfiguration("use_bbox_to_3d")
+    use_keypoint_to_3d = LaunchConfiguration("use_keypoint_to_3d")
+    use_mask_to_3d = LaunchConfiguration("use_mask_to_3d")
 
     launch_args = [
         DeclareLaunchArgument(
@@ -85,12 +86,17 @@ def generate_launch_description():
             description="IoU threshold",
         ),
         DeclareLaunchArgument(
-            "use_3d",
+            "use_bbox_to_3d",
             default_value="True",
-            description="Whether to activate 3D detections",
+            description="Whether to activate bbox_to_3d",
         ),
         DeclareLaunchArgument(
-            "use_mask_3d",
+            "use_keypoint_to_3d",
+            default_value="True",
+            description="Whether to activate keypoint_to_3d",
+        ),
+        DeclareLaunchArgument(
+            "use_mask_to_3d",
             default_value="False",
             description="Whether to activate mask_to_3d",
         ),
@@ -145,7 +151,7 @@ def generate_launch_description():
             "execute_default": execute_default,
             "bbox_topic_name": [LaunchConfiguration("node_name"), "/object_boxes"],
         }.items(),
-        condition=IfCondition(use_3d),
+        condition=IfCondition(use_bbox_to_3d),
     )
 
     keypoint_to_3d_cmd = IncludeLaunchDescription(
@@ -158,7 +164,7 @@ def generate_launch_description():
             "execute_default": execute_default,
             "keypoint_topic_name": [LaunchConfiguration("node_name"), "/object_keypoints"],
         }.items(),
-        condition=IfCondition(use_3d),
+        condition=IfCondition(use_keypoint_to_3d),
     )
 
     mask_to_3d_cmd = IncludeLaunchDescription(
@@ -171,7 +177,7 @@ def generate_launch_description():
             "execute_default": execute_default,
             "mask_topic_name": [LaunchConfiguration("node_name"), "/object_masks"],
         }.items(),
-        condition=IfCondition(AndSubstitution(use_3d, use_mask_3d)),
+        condition=IfCondition(use_mask_to_3d),
     )
 
     return LaunchDescription(

--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -3,7 +3,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, AndSubstitution, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from launch.conditions import IfCondition


### PR DESCRIPTION
## Summary

This PR separates the 3D launch control in `yolo.launch.py` into independent launch arguments for each 3D pipeline.

Previously, `use_3d` controlled both `bbox_to_3d` and `keypoint_to_3d`, while `use_mask_3d` was additionally combined with `use_3d` for `mask_to_3d`.

This change introduces:
- `use_bbox_to_3d`
- `use_keypoint_to_3d`
- `use_mask_to_3d`

## Changes

- Replaced `use_3d` with `use_bbox_to_3d` for `bbox_to_3d.launch.py`
- Added `use_keypoint_to_3d` for `keypoint_to_3d.launch.py`
- Renamed `use_mask_3d` to `use_mask_to_3d`
- Updated launch conditions so:
  - `bbox_to_3d` launches only when `use_bbox_to_3d:=True`
  - `keypoint_to_3d` launches only when `use_keypoint_to_3d:=True`
  - `mask_to_3d` launches only when `use_mask_to_3d:=True`

## Why

This makes each 3D pipeline independently controllable.

That allows users to:
- launch only bounding-box-based 3D estimation
- launch only keypoint-based 3D estimation
- launch only mask-based 3D estimation
- combine them as needed depending on the model and use case

## Example

```bash
ros2 launch yolo_ros yolo.launch.py \
  use_bbox_to_3d:=True \
  use_keypoint_to_3d:=False \
  use_mask_to_3d:=False