### PR TITLE
Feat/lifecycle auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <a name="readme-top"></a>
 
+[EN](README.md) | [JA](README_ja.md)
+
 [![Contributors][contributors-shield]][contributors-url]
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
@@ -9,43 +11,42 @@
 # Yolo ROS
 
 <details>
-  <summary>目次</summary>
+  <summary>Table of Contents</summary>
   <ol>
     <li>
-      <a href="#概要">概要</a>
+      <a href="#overview">Overview</a>
     </li>
     <li>
-      <a href="#対応モデル">対応モデル</a>
+      <a href="#supported-models">Supported Models</a>
     </li>
     <li>
-      <a href="#セットアップ">セットアップ</a>
+      <a href="#setup">Setup</a>
       <ul>
-        <li><a href="#環境条件">環境条件</a></li>
-        <li><a href="#インストール方法">インストール方法</a></li>
+        <li><a href="#environment">Environment</a></li>
+        <li><a href="#installation">Installation</a></li>
       </ul>
     </li>
-    <li><a href="#実行操作方法">実行・操作方法</a></li>
-    <li><a href="#パラメーター">パラメーター</a></li>
-    <li><a href="#入出力">入出力</a></li>
-    <li><a href="#ライフサイクルノード">ライフサイクルノード</a></li>
-    <li><a href="#デモ">デモ</a></li>
-     <li><a href="#マイルストーン">マイルストーン</a></li>
-    <li><a href="#参考文献">参考文献</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#parameters">Parameters</a></li>
+    <li><a href="#demo">Demo</a></li>
+    <li><a href="#references">References</a></li>
   </ol>
 </details>
 
-## 概要
-yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOLOEなど）をROS 2で利用するためのラッパーです．これにより，以下の機能がROS 2環境で実現できます．
+## Overview
+`yolo_ros` is a wrapper package for using Ultralytics YOLO models in ROS 2, including YOLOv3 through YOLOv11, YOLO-NAS, and YOLOE.
 
-- 物体検出 (Object Detection)
-- 人間の姿勢推定 (Human Pose Estimation)
-- インスタンスセグメンテーション (Instance Segmentation)
-- YOLOEによる効率的な推論とプロンプトベースの検出
+It provides the following features in a ROS 2 environment:
 
-## セットアップ
-本レポジトリのセットアップ方法について説明します．
+- Object detection
+- Human pose estimation
+- Instance segmentation
+- Efficient inference and prompt-based detection with YOLOE
 
-### 環境条件
+## Setup
+This section explains how to set up this repository.
+
+### Environment
 
 | System  | Version |
 | ------------- | ------------- |
@@ -53,42 +54,42 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
 | ROS | Jazzy Jalisco |
 | Python | 3.10~ |
 
-### インストール方法
-1. ROS 2の`src`フォルダに移動します．
+### Installation
+1. Move to your ROS 2 `src` directory.
    ```sh
    cd ~/colcon_ws/src/
    ```
-2. 本レポジトリをcloneします．
+2. Clone this repository.
    ```sh
    git clone -b jazzy-devel https://github.com/TeamSOBITS/yolo_ros.git
    ```
-3. レポジトリの中へ移動します．
+3. Move into the repository.
    ```sh
    cd yolo_ros
    ```
-4. 依存パッケージをインストールします．
+4. Install dependencies.
     ```sh
     bash install.sh
     ```
-5. パッケージをコンパイルします．
+5. Build the package.
    ```sh
    cd ~/colcon_ws/
    colcon build --symlink-install
    ```
 
-## 実行・操作方法
-1. カメラを起動し，[yolo.launch.py](https://github.com/TeamSOBITS/yolo_ros/blob/jazzy-devel/launch/yolo.launch.py)の**image_topic_name**を使用するカメラのトピック名に書き換える．
+## Usage
+1. Launch your camera and update **image_topic_name** in [yolo.launch.py](https://github.com/TeamSOBITS/yolo_ros/blob/jazzy-devel/launch/yolo.launch.py) to match your camera topic.
 
     ```sh
     ros2 launch yolo_ros yolo.launch.py
     ```
 
-2. カスタムの重みファイルを使用する場合：
-    - 用意した`.pt`ファイルを`weights`に配置してください．
+2. If you want to use a custom weight file:
+   - Place your `.pt` file in the `weights` directory.
 
-3. 3D座標変換（物体位置推定）を使用する場合は，必要な3Dパイプラインを起動引数で切り替える．
+3. If you want to use 3D coordinate conversion for object position estimation, enable the required 3D pipelines with launch arguments.
 
-    例：`bbox_to_3d` のみを有効にする場合
+    Example: enable only `bbox_to_3d`
     ```sh
     ros2 launch yolo_ros yolo.launch.py \
       use_bbox_to_3d:=True \
@@ -96,7 +97,7 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
       use_mask_to_3d:=False
     ```
 
-    例：`bbox_to_3d` と `keypoint_to_3d` を有効にする場合
+    Example: enable both `bbox_to_3d` and `keypoint_to_3d`
     ```sh
     ros2 launch yolo_ros yolo.launch.py \
       use_bbox_to_3d:=True \
@@ -104,27 +105,36 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
       use_mask_to_3d:=False
     ```
 
-## パラメーター
-以下は[yolo.launch.py](https://github.com/TeamSOBITS/yolo_ros/blob/jazzy-devel/launch/yolo.launch.py)およびノードで設定可能な主なパラメーターです．
-詳細は[Ultralytics Predict](https://docs.ultralytics.com/modes/predict/#inference-arguments)も参照してください．
+4. If you want to control YOLO lifecycle startup transitions independently:
+    ```sh
+    ros2 launch yolo_ros yolo.launch.py \
+      auto_configure:=True \
+      auto_activate:=False
+    ```
 
-| パラメーター名            | 型            | 説明                               |
+## Parameters
+The following are the main parameters available in [yolo.launch.py](https://github.com/TeamSOBITS/yolo_ros/blob/jazzy-devel/launch/yolo.launch.py) and the node itself.
+See [Ultralytics Predict](https://docs.ultralytics.com/modes/predict/#inference-arguments) for additional inference arguments.
+
+| Parameter          | Type         | Description                        |
 | ------------------ | ------------ | -------------------------------- |
-| image_topic_name   | string       | 入力となる画像トピック名                     |
-| weight_file        | string       | 使用する重みファイル名（weightsフォルダ内）        |
-| weights_path       | string       | 重みファイルが保存されているディレクトリパス           |
-| execute_default    | bool         | 起動時に自動でノードをConfigure/Activateするか |
-| conf               | double       | 検出の信頼度しきい値                       |
-| iou                | double       | NMSのIoUしきい値                      |
-| use_bbox_to_3d     | bool         | bbox_to_3d を起動するか                |
-| use_keypoint_to_3d | bool         | keypoint_to_3d を起動するか            |
-| use_mask_to_3d     | bool         | mask_to_3d を起動するか                |
-| filter_classes     | string_array | 検出対象を絞り込むクラス名のリスト                |
-| keypoint_name_list | string_array | 姿勢推定時のキーポイント名のリスト                |
-| yoloe_prompts      | string_array | YOLOEで使用する検出プロンプト                |
+| image_topic_name   | string       | Input image topic name             |
+| weight_file        | string       | Weight file name in the `weights` directory |
+| weights_path       | string       | Directory path where weight files are stored |
+| auto_configure     | bool         | Whether to configure the YOLO lifecycle node on startup |
+| auto_activate      | bool         | Whether to activate the YOLO lifecycle node on startup |
+| execute_default    | bool         | Whether to auto-configure and auto-activate included 3D lifecycle nodes on startup |
+| conf               | double       | Detection confidence threshold     |
+| iou                | double       | NMS IoU threshold                  |
+| use_bbox_to_3d     | bool         | Whether to launch `bbox_to_3d`     |
+| use_keypoint_to_3d | bool         | Whether to launch `keypoint_to_3d` |
+| use_mask_to_3d     | bool         | Whether to launch `mask_to_3d`     |
+| filter_classes     | string_array | List of class names to filter detections |
+| keypoint_name_list | string_array | List of keypoint names for pose estimation |
+| yoloe_prompts      | string_array | Detection prompts used by YOLOE    |
 
-## デモ
-| 物体検出 | 姿勢推定 | セグメンテーション |
+## Demo
+| Object Detection | Pose Estimation | Segmentation |
 |:---:|:---:|:---:|
 | ![](docs/yolo26n.jpg) | ![](docs/yolo26n-pose.jpg) | ![](docs/yoloe-26n-seg.jpg) |
 
@@ -153,7 +163,7 @@ ros2 param set /yolo_ros weight_file "yoloe-26n-seg.pt"
 ros2 param set /yolo_ros yoloe_prompts "['bottle', 'laptop']"
 ```
 
-## 参考文献
+## References
 * [Ultralytics Documentation](https://docs.ultralytics.com/)
 
 [contributors-shield]: https://img.shields.io/github/contributors/TeamSOBITS/yolo_ros.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ This section explains how to set up this repository.
 4. If you want to control YOLO lifecycle startup transitions independently:
     ```sh
     ros2 launch yolo_ros yolo.launch.py \
-      auto_configure:=True \
-      auto_activate:=False
+      auto_configure_2d:=True \
+      auto_activate_2d:=False
     ```
 
 ## Parameters
@@ -121,9 +121,10 @@ See [Ultralytics Predict](https://docs.ultralytics.com/modes/predict/#inference-
 | image_topic_name   | string       | Input image topic name             |
 | weight_file        | string       | Weight file name in the `weights` directory |
 | weights_path       | string       | Directory path where weight files are stored |
-| auto_configure     | bool         | Whether to configure the YOLO lifecycle node on startup |
-| auto_activate      | bool         | Whether to activate the YOLO lifecycle node on startup |
-| execute_default    | bool         | Whether to auto-configure and auto-activate included 3D lifecycle nodes on startup |
+| auto_configure_2d  | bool         | Whether to configure the YOLO lifecycle node on startup |
+| auto_activate_2d   | bool         | Whether to activate the YOLO lifecycle node on startup |
+| auto_configure_3d  | bool         | Whether to configure the Image to Position lifecycle node on startup |
+| auto_activate_3d   | bool         | Whether to activate the Image to Position lifecycle node on startup |
 | conf               | double       | Detection confidence threshold     |
 | iou                | double       | NMS IoU threshold                  |
 | use_bbox_to_3d     | bool         | Whether to launch `bbox_to_3d`     |

--- a/README_ja.md
+++ b/README_ja.md
@@ -107,8 +107,8 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
 4. YOLOライフサイクルノードの起動時遷移を個別に切り替える場合：
     ```sh
     ros2 launch yolo_ros yolo.launch.py \
-      auto_configure:=True \
-      auto_activate:=False
+      auto_configure_2d:=True \
+      auto_activate_2d:=False
     ```
 
 ## パラメーター
@@ -120,9 +120,10 @@ yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOL
 | image_topic_name   | string       | 入力となる画像トピック名                     |
 | weight_file        | string       | 使用する重みファイル名（weightsフォルダ内）        |
 | weights_path       | string       | 重みファイルが保存されているディレクトリパス           |
-| auto_configure     | bool         | 起動時にYOLOライフサイクルノードをConfigureするか |
-| auto_activate      | bool         | 起動時にYOLOライフサイクルノードをActivateするか |
-| execute_default    | bool         | 起動時に含まれる3Dライフサイクルノードを自動でConfigure/Activateするか |
+| auto_configure_2d  | bool         | 起動時にYOLOライフサイクルノードをConfigureするか |
+| auto_activate_2d   | bool         | 起動時にYOLOライフサイクルノードをActivateするか |
+| auto_configure_3d  | bool         | 起動時にImage to PositionライフサイクルノードをConfigureするか |
+| auto_activate_3d   | bool         | 起動時にImage to PositionライフサイクルノードをActivateするか |
 | conf               | double       | 検出の信頼度しきい値                       |
 | iou                | double       | NMSのIoUしきい値                      |
 | use_bbox_to_3d     | bool         | bbox_to_3d を起動するか                |

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,177 @@
+<a name="readme-top"></a>
+
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![License][license-shield]][license-url]
+
+# Yolo ROS
+
+<details>
+  <summary>目次</summary>
+  <ol>
+    <li>
+      <a href="#概要">概要</a>
+    </li>
+    <li>
+      <a href="#対応モデル">対応モデル</a>
+    </li>
+    <li>
+      <a href="#セットアップ">セットアップ</a>
+      <ul>
+        <li><a href="#環境条件">環境条件</a></li>
+        <li><a href="#インストール方法">インストール方法</a></li>
+      </ul>
+    </li>
+    <li><a href="#実行操作方法">実行・操作方法</a></li>
+    <li><a href="#パラメーター">パラメーター</a></li>
+    <li><a href="#入出力">入出力</a></li>
+    <li><a href="#ライフサイクルノード">ライフサイクルノード</a></li>
+    <li><a href="#デモ">デモ</a></li>
+     <li><a href="#マイルストーン">マイルストーン</a></li>
+    <li><a href="#参考文献">参考文献</a></li>
+  </ol>
+</details>
+
+## 概要
+yolo_rosは，UltralyticsのYOLOモデル（YOLOv3からYOLOv11，YOLO-NAS，YOLOEなど）をROS 2で利用するためのラッパーです．これにより，以下の機能がROS 2環境で実現できます．
+
+- 物体検出 (Object Detection)
+- 人間の姿勢推定 (Human Pose Estimation)
+- インスタンスセグメンテーション (Instance Segmentation)
+- YOLOEによる効率的な推論とプロンプトベースの検出
+
+## セットアップ
+本レポジトリのセットアップ方法について説明します．
+
+### 環境条件
+
+| System  | Version |
+| ------------- | ------------- |
+| Ubuntu | 24.04 (Noble Numbat) |
+| ROS | Jazzy Jalisco |
+| Python | 3.10~ |
+
+### インストール方法
+1. ROS 2の`src`フォルダに移動します．
+   ```sh
+   cd ~/colcon_ws/src/
+   ```
+2. 本レポジトリをcloneします．
+   ```sh
+   git clone -b jazzy-devel https://github.com/TeamSOBITS/yolo_ros.git
+   ```
+3. レポジトリの中へ移動します．
+   ```sh
+   cd yolo_ros
+   ```
+4. 依存パッケージをインストールします．
+    ```sh
+    bash install.sh
+    ```
+5. パッケージをコンパイルします．
+   ```sh
+   cd ~/colcon_ws/
+   colcon build --symlink-install
+   ```
+
+## 実行・操作方法
+1. カメラを起動し，[yolo.launch.py](https://github.com/TeamSOBITS/yolo_ros/blob/jazzy-devel/launch/yolo.launch.py)の**image_topic_name**を使用するカメラのトピック名に書き換える．
+
+    ```sh
+    ros2 launch yolo_ros yolo.launch.py
+    ```
+
+2. カスタムの重みファイルを使用する場合：
+    - 用意した`.pt`ファイルを`weights`に配置してください．
+
+3. 3D座標変換（物体位置推定）を使用する場合は，必要な3Dパイプラインを起動引数で切り替える．
+
+    例：`bbox_to_3d` のみを有効にする場合
+    ```sh
+    ros2 launch yolo_ros yolo.launch.py \
+      use_bbox_to_3d:=True \
+      use_keypoint_to_3d:=False \
+      use_mask_to_3d:=False
+    ```
+
+    例：`bbox_to_3d` と `keypoint_to_3d` を有効にする場合
+    ```sh
+    ros2 launch yolo_ros yolo.launch.py \
+      use_bbox_to_3d:=True \
+      use_keypoint_to_3d:=True \
+      use_mask_to_3d:=False
+    ```
+
+4. YOLOライフサイクルノードの起動時遷移を個別に切り替える場合：
+    ```sh
+    ros2 launch yolo_ros yolo.launch.py \
+      auto_configure:=True \
+      auto_activate:=False
+    ```
+
+## パラメーター
+以下は[yolo.launch.py](https://github.com/TeamSOBITS/yolo_ros/blob/jazzy-devel/launch/yolo.launch.py)およびノードで設定可能な主なパラメーターです．
+詳細は[Ultralytics Predict](https://docs.ultralytics.com/modes/predict/#inference-arguments)も参照してください．
+
+| パラメーター名            | 型            | 説明                               |
+| ------------------ | ------------ | -------------------------------- |
+| image_topic_name   | string       | 入力となる画像トピック名                     |
+| weight_file        | string       | 使用する重みファイル名（weightsフォルダ内）        |
+| weights_path       | string       | 重みファイルが保存されているディレクトリパス           |
+| auto_configure     | bool         | 起動時にYOLOライフサイクルノードをConfigureするか |
+| auto_activate      | bool         | 起動時にYOLOライフサイクルノードをActivateするか |
+| execute_default    | bool         | 起動時に含まれる3Dライフサイクルノードを自動でConfigure/Activateするか |
+| conf               | double       | 検出の信頼度しきい値                       |
+| iou                | double       | NMSのIoUしきい値                      |
+| use_bbox_to_3d     | bool         | bbox_to_3d を起動するか                |
+| use_keypoint_to_3d | bool         | keypoint_to_3d を起動するか            |
+| use_mask_to_3d     | bool         | mask_to_3d を起動するか                |
+| filter_classes     | string_array | 検出対象を絞り込むクラス名のリスト                |
+| keypoint_name_list | string_array | 姿勢推定時のキーポイント名のリスト                |
+| yoloe_prompts      | string_array | YOLOEで使用する検出プロンプト                |
+
+## デモ
+| 物体検出 | 姿勢推定 | セグメンテーション |
+|:---:|:---:|:---:|
+| ![](docs/yolo26n.jpg) | ![](docs/yolo26n-pose.jpg) | ![](docs/yoloe-26n-seg.jpg) |
+
+### Detection
+  ```bash
+  ros2 param set /yolo_ros weight_file "yolo26n.pt"
+  ros2 param set /yolo_ros filter_classes "['person', 'laptop']"
+  ros2 param set /yolo_ros filter_classes "['']"
+  ```
+
+### Pose
+```bash
+ros2 param set /yolo_ros weight_file "yolo26n-pose.pt"
+```
+
+### Segmentation
+```bash
+ros2 param set /yolo_ros weight_file "yolo26n-seg.pt"
+ros2 param set /yolo_ros filter_classes "['person', 'laptop']"
+ros2 param set /yolo_ros filter_classes "['']"
+```
+
+### YOLOE Segmentation
+```bash
+ros2 param set /yolo_ros weight_file "yoloe-26n-seg.pt"
+ros2 param set /yolo_ros yoloe_prompts "['bottle', 'laptop']"
+```
+
+## 参考文献
+* [Ultralytics Documentation](https://docs.ultralytics.com/)
+
+[contributors-shield]: https://img.shields.io/github/contributors/TeamSOBITS/yolo_ros.svg?style=for-the-badge
+[contributors-url]: https://github.com/TeamSOBITS/yolo_ros/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/TeamSOBITS/yolo_ros.svg?style=for-the-badge
+[forks-url]: https://github.com/TeamSOBITS/yolo_ros/network/members
+[stars-shield]: https://img.shields.io/github/stars/TeamSOBITS/yolo_ros.svg?style=for-the-badge
+[stars-url]: https://github.com/TeamSOBITS/yolo_ros/stargazers
+[issues-shield]: https://img.shields.io/github/issues/TeamSOBITS/yolo_ros.svg?style=for-the-badge
+[issues-url]: https://github.com/TeamSOBITS/yolo_ros/issues
+[license-shield]: https://img.shields.io/github/license/TeamSOBITS/yolo_ros.svg?style=for-the-badge
+[license-url]: LICENSE

--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -16,9 +16,10 @@ def generate_launch_description():
     bbox_to_3d_params_file = LaunchConfiguration("bbox_to_3d_params_file")
     keypoint_to_3d_params_file = LaunchConfiguration("keypoint_to_3d_params_file")
     mask_to_3d_params_file = LaunchConfiguration("mask_to_3d_params_file")
-    auto_configure = LaunchConfiguration("auto_configure")
-    auto_activate = LaunchConfiguration("auto_activate")
-    execute_default = LaunchConfiguration("execute_default")
+    auto_configure_2d = LaunchConfiguration("auto_configure_2d")
+    auto_activate_2d = LaunchConfiguration("auto_activate_2d")
+    auto_configure_3d = LaunchConfiguration("auto_configure_3d")
+    auto_activate_3d = LaunchConfiguration("auto_activate_3d")
     conf = LaunchConfiguration("conf")
     iou = LaunchConfiguration("iou")
     use_bbox_to_3d = LaunchConfiguration("use_bbox_to_3d")
@@ -73,19 +74,24 @@ def generate_launch_description():
             description="Parameter file path for mask_to_3d",
         ),
         DeclareLaunchArgument(
-            "auto_configure",
+            "auto_configure_2d",
             default_value="True",
             description="Whether to configure the YOLO lifecycle node on startup",
         ),
         DeclareLaunchArgument(
-            "auto_activate",
+            "auto_activate_2d",
             default_value="True",
             description="Whether to activate the YOLO lifecycle node on startup",
         ),
         DeclareLaunchArgument(
-            "execute_default",
+            "auto_configure_3d",
             default_value="True",
-            description="Whether to auto-configure and auto-activate included 3D lifecycle nodes",
+            description="Whether to configure the Image to Position lifecycle node on startup",
+        ),
+        DeclareLaunchArgument(
+            "auto_activate_3d",
+            default_value="True",
+            description="Whether to activate the Image to Position lifecycle node on startup",
         ),
         DeclareLaunchArgument(
             "conf",
@@ -142,8 +148,8 @@ def generate_launch_description():
                 "image_topic_name": image_topic_name,
                 "weight_file": weight_file,
                 "weights_path": weights_path,
-                "auto_configure": auto_configure,
-                "auto_activate": auto_activate,
+                "auto_configure": auto_configure_2d,
+                "auto_activate": auto_activate_2d,
                 "conf": conf,
                 "iou": iou,
             },
@@ -161,7 +167,8 @@ def generate_launch_description():
         launch_arguments={
             "namespace": namespace,
             "params_file": bbox_to_3d_params_file,
-            "execute_default": execute_default,
+            "auto_configure": auto_configure_3d,
+            "auto_activate": auto_activate_3d,
             "bbox_topic_name": [LaunchConfiguration("node_name"), "/object_boxes"],
         }.items(),
         condition=IfCondition(use_bbox_to_3d),
@@ -174,7 +181,8 @@ def generate_launch_description():
         launch_arguments={
             "namespace": namespace,
             "params_file": keypoint_to_3d_params_file,
-            "execute_default": execute_default,
+            "auto_configure": auto_configure_3d,
+            "auto_activate": auto_activate_3d,
             "keypoint_topic_name": [LaunchConfiguration("node_name"), "/object_keypoints"],
         }.items(),
         condition=IfCondition(use_keypoint_to_3d),
@@ -187,7 +195,8 @@ def generate_launch_description():
         launch_arguments={
             "namespace": namespace,
             "params_file": mask_to_3d_params_file,
-            "execute_default": execute_default,
+            "auto_configure": auto_configure_3d,
+            "auto_activate": auto_activate_3d,
             "mask_topic_name": [LaunchConfiguration("node_name"), "/object_masks"],
         }.items(),
         condition=IfCondition(use_mask_to_3d),

--- a/launch/yolo.launch.py
+++ b/launch/yolo.launch.py
@@ -16,6 +16,8 @@ def generate_launch_description():
     bbox_to_3d_params_file = LaunchConfiguration("bbox_to_3d_params_file")
     keypoint_to_3d_params_file = LaunchConfiguration("keypoint_to_3d_params_file")
     mask_to_3d_params_file = LaunchConfiguration("mask_to_3d_params_file")
+    auto_configure = LaunchConfiguration("auto_configure")
+    auto_activate = LaunchConfiguration("auto_activate")
     execute_default = LaunchConfiguration("execute_default")
     conf = LaunchConfiguration("conf")
     iou = LaunchConfiguration("iou")
@@ -71,9 +73,19 @@ def generate_launch_description():
             description="Parameter file path for mask_to_3d",
         ),
         DeclareLaunchArgument(
+            "auto_configure",
+            default_value="True",
+            description="Whether to configure the YOLO lifecycle node on startup",
+        ),
+        DeclareLaunchArgument(
+            "auto_activate",
+            default_value="True",
+            description="Whether to activate the YOLO lifecycle node on startup",
+        ),
+        DeclareLaunchArgument(
             "execute_default",
             default_value="True",
-            description="Whether to auto-configure and auto-activate the YOLO lifecycle node",
+            description="Whether to auto-configure and auto-activate included 3D lifecycle nodes",
         ),
         DeclareLaunchArgument(
             "conf",
@@ -130,7 +142,8 @@ def generate_launch_description():
                 "image_topic_name": image_topic_name,
                 "weight_file": weight_file,
                 "weights_path": weights_path,
-                "execute_default": execute_default,
+                "auto_configure": auto_configure,
+                "auto_activate": auto_activate,
                 "conf": conf,
                 "iou": iou,
             },

--- a/yolo_ros/yolo_node.py
+++ b/yolo_ros/yolo_node.py
@@ -19,8 +19,8 @@ class YoloNode(LifecycleNode):
         self.declare_parameter("image_topic_name", "camera/color/image_raw")
         self.declare_parameter("weight_file", "yolo26n.pt")
         self.declare_parameter("weights_path", "")
-        self.declare_parameter("auto_configure_2d", True)
-        self.declare_parameter("auto_activate_2d", True)
+        self.declare_parameter("auto_configure", True)
+        self.declare_parameter("auto_activate", True)
         self.declare_parameter("conf", 0.35)
         self.declare_parameter("iou", 0.7)
 
@@ -232,12 +232,12 @@ def main(args=None):
     rclpy.init(args=args)
     node = YoloNode()
 
-    auto_configure_2d = node.get_parameter("auto_configure_2d").get_parameter_value().bool_value
-    auto_activate_2d = node.get_parameter("auto_activate_2d").get_parameter_value().bool_value
+    auto_configure = node.get_parameter("auto_configure").get_parameter_value().bool_value
+    auto_activate = node.get_parameter("auto_activate").get_parameter_value().bool_value
 
-    if auto_configure_2d or auto_activate_2d:
+    if auto_configure or auto_activate:
         node.trigger_configure()
-    if auto_activate_2d:
+    if auto_activate:
         node.trigger_activate()
     try:
         rclpy.spin(node)

--- a/yolo_ros/yolo_node.py
+++ b/yolo_ros/yolo_node.py
@@ -19,8 +19,8 @@ class YoloNode(LifecycleNode):
         self.declare_parameter("image_topic_name", "camera/color/image_raw")
         self.declare_parameter("weight_file", "yolo26n.pt")
         self.declare_parameter("weights_path", "")
-        self.declare_parameter("auto_configure", True)
-        self.declare_parameter("auto_activate", True)
+        self.declare_parameter("auto_configure_2d", True)
+        self.declare_parameter("auto_activate_2d", True)
         self.declare_parameter("conf", 0.35)
         self.declare_parameter("iou", 0.7)
 
@@ -232,12 +232,12 @@ def main(args=None):
     rclpy.init(args=args)
     node = YoloNode()
 
-    auto_configure = node.get_parameter("auto_configure").get_parameter_value().bool_value
-    auto_activate = node.get_parameter("auto_activate").get_parameter_value().bool_value
+    auto_configure_2d = node.get_parameter("auto_configure_2d").get_parameter_value().bool_value
+    auto_activate_2d = node.get_parameter("auto_activate_2d").get_parameter_value().bool_value
 
-    if auto_configure or auto_activate:
+    if auto_configure_2d or auto_activate_2d:
         node.trigger_configure()
-    if auto_activate:
+    if auto_activate_2d:
         node.trigger_activate()
     try:
         rclpy.spin(node)

--- a/yolo_ros/yolo_node.py
+++ b/yolo_ros/yolo_node.py
@@ -235,10 +235,18 @@ def main(args=None):
     auto_configure = node.get_parameter("auto_configure").get_parameter_value().bool_value
     auto_activate = node.get_parameter("auto_activate").get_parameter_value().bool_value
 
+    configure_succeeded = True
     if auto_configure or auto_activate:
-        node.trigger_configure()
+        configure_result = node.trigger_configure()
+        configure_succeeded = configure_result == TransitionCallbackReturn.SUCCESS
     if auto_activate:
-        node.trigger_activate()
+        if configure_succeeded:
+            node.trigger_activate()
+        else:
+            node.get_logger().error(
+                "Auto-activation requested, but node configuration failed; "
+                "skipping activation."
+            )
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:

--- a/yolo_ros/yolo_node.py
+++ b/yolo_ros/yolo_node.py
@@ -19,7 +19,8 @@ class YoloNode(LifecycleNode):
         self.declare_parameter("image_topic_name", "camera/color/image_raw")
         self.declare_parameter("weight_file", "yolo26n.pt")
         self.declare_parameter("weights_path", "")
-        self.declare_parameter("execute_default", True)
+        self.declare_parameter("auto_configure", True)
+        self.declare_parameter("auto_activate", True)
         self.declare_parameter("conf", 0.35)
         self.declare_parameter("iou", 0.7)
 
@@ -231,9 +232,12 @@ def main(args=None):
     rclpy.init(args=args)
     node = YoloNode()
 
-    execute_default = node.get_parameter("execute_default").get_parameter_value().bool_value
-    if execute_default:
+    auto_configure = node.get_parameter("auto_configure").get_parameter_value().bool_value
+    auto_activate = node.get_parameter("auto_activate").get_parameter_value().bool_value
+
+    if auto_configure or auto_activate:
         node.trigger_configure()
+    if auto_activate:
         node.trigger_activate()
     try:
         rclpy.spin(node)


### PR DESCRIPTION
## Summary

This PR improves lifecycle startup control in `yolo_ros` by separating YOLO node startup transitions into explicit parameters, and updates the launch interface and documentation accordingly.

It also separates the 3D launch toggles for `bbox_to_3d`, `keypoint_to_3d`, and `mask_to_3d`, and adds a Japanese README alongside the English README.

## Changes

- Added `auto_configure` to control whether the YOLO lifecycle node is configured on startup
- Added `auto_activate` to control whether the YOLO lifecycle node is activated on startup
- Updated `yolo_node.py` so:
  - `auto_configure:=True` configures the node on startup
  - `auto_activate:=True` activates the node on startup
  - `auto_activate:=True` also triggers configure first when needed
- Kept `execute_default` for included 3D lifecycle nodes only
- Replaced the old 3D launch flags:
  - `use_3d` -> `use_bbox_to_3d`
  - `use_mask_3d` -> `use_mask_to_3d`
- Added `use_keypoint_to_3d`
- Updated launch conditions so:
  - `bbox_to_3d` launches only when `use_bbox_to_3d:=True`
  - `keypoint_to_3d` launches only when `use_keypoint_to_3d:=True`
  - `mask_to_3d` launches only when `use_mask_to_3d:=True`
- Updated `README.md` in English
- Added `README_ja.md` based on the Japanese content

## Why

Previously, `execute_default` was ambiguous because it implied both configure and activate behavior for the YOLO lifecycle node.

This change makes lifecycle startup behavior more explicit and easier to control, especially when users want the node to stop after `configure` without immediately activating it.

Separating the 3D launch flags also makes each 3D pipeline independently controllable.

## Example

```bash
ros2 launch yolo_ros yolo.launch.py \
  auto_configure:=True \
  auto_activate:=False \
  use_bbox_to_3d:=True \
  use_keypoint_to_3d:=False \
  use_mask_to_3d:=False
```

## Documentation
README.md was rewritten in English
README_ja.md was added for the Japanese version
Usage examples and parameter tables were updated to reflect:
auto_configure
auto_activate
use_bbox_to_3d
use_keypoint_to_3d
use_mask_to_3d